### PR TITLE
fix hover effects issue in footer nav

### DIFF
--- a/src/components/components.css
+++ b/src/components/components.css
@@ -40,7 +40,7 @@
       z-index: 1;
     }
   
-    .nav-links:hover {
+    nav .nav-links:hover {
       background-color: #5271FF;
       color: #fff;
       border-radius: 0;


### PR DESCRIPTION
Fix hover effects issue in footer nav when the browser is less than or equal to 960px.